### PR TITLE
Deduplicate projects by subpath

### DIFF
--- a/src/lib/cli/timelines/index.ts
+++ b/src/lib/cli/timelines/index.ts
@@ -79,7 +79,9 @@ async function collectAllStats(cacheDir: string, outfile: string, configs: Reado
                 throw new Error(`Could not find a config at idx '${ idx }'`);
             }
 
-            return { projectName: repoName(config.repoUrl), stats: stat };
+            const repo = repoName(config.repoUrl);
+            const projectName = config.subprojectPath !== "/" ? `${ repo } at ${ config.subprojectPath }` : repo;
+            return { projectName, stats: stat };
         }));
         writeFileSync(outfile, Buffer.from(statsDB.export()));
         console.log(statsMessage(outfile));


### PR DESCRIPTION
Processed stats are recorded against a project, with a constraint that the project has to be unique. This fails in cases where a single repo is processed with different subproject paths.

This PR records at which subpath in the repo the data was collected.