### PR TITLE
Feat/track multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Config is a .js file with an array of entries for each repo you want to process.
 }
 ```
 
+`isTargetModuleOrPath` can also be an object of regular expressions, if you want to track adoption of multiple targets:
+```ts
+{
+  repoUrl: "https://github.com/company/product",
+  isTargetModuleOrPath: {
+    ds: /^@company\/design-system/,
+    oldComponenentLibrary: /^@company\/legacy-comp-lib/,
+    newComponenentLibrary: /^@company\/my-new-comp-lib/,
+  },
+  maxWeeks: 52,
+}
+```
+
+
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Config is a .js file with an array of entries for each repo you want to process.
 }
 ```
 
-`isTargetModuleOrPath` can also be an object of regular expressions, if you want to track adoption of multiple targets:
+`isTargetModuleOrPath` can also be an set of regular expressions, if you want to track adoption of multiple targets:
 ```ts
 {
   repoUrl: "https://github.com/company/product",

--- a/src/lib/cli/collectStats.ts
+++ b/src/lib/cli/collectStats.ts
@@ -80,7 +80,7 @@ export async function collectStats(config: ResolvedStatsConfig, tag: () => strin
                 && config.isTargetImport(imp);
         };
 
-    const isTargetModuleOrPathMap = isRegexp(config.isTargetModuleOrPath) ? { default: config.isTargetModuleOrPath } : config.isTargetModuleOrPath;
+    const isTargetModuleOrPathMap = isRegexp(config.isTargetModuleOrPath) ? { target: config.isTargetModuleOrPath } : config.isTargetModuleOrPath;
 
     // extract this outside of function to reduce re-calculation for each file
     const anyTargetModuleOrPathRexExes = objectValues(isTargetModuleOrPathMap);

--- a/src/lib/cli/resolveStatsConfig.ts
+++ b/src/lib/cli/resolveStatsConfig.ts
@@ -1,4 +1,4 @@
-import { hasProp, isFunction, isNull, isRegexp, isString, StringKeys } from "../guards";
+import { hasProp, isFunction, isNull, isObject, isRegexp, isString, objectValues, StringKeys } from "../guards";
 import { ResolvedStatsConfig, StatsConfig } from "./sharedTypes";
 
 const isIgnoredFileKey: StringKeys<StatsConfig> = "isIgnoredFile";
@@ -49,7 +49,9 @@ export const resolveStatsConfig = (config: StatsConfig | unknown): ResolvedStats
 
     if (!hasIsTargetModuleOrPath(config)) { throw new Error("Expected the config to specify isTargetModuleOrPath regexp"); }
     const isTargetModuleOrPath = config.isTargetModuleOrPath;
-    if (!isRegexp(isTargetModuleOrPath)) { throw new Error(`Expected a regexp isTargetModuleOrPath, got: ${ isTargetModuleOrPath }`); }
+    if (!isRegexp(isTargetModuleOrPath) && !(isObject(isTargetModuleOrPath) && objectValues(isTargetModuleOrPath).reduce((acc, v) => acc && isRegexp(v), true))) {
+        throw new Error(`Expected a regexp or object of regexp isTargetModuleOrPath, got: ${ isTargetModuleOrPath }`);
+    }
 
     const isTargetImport = hasIsTargetImport(config) && config.isTargetImport ? config.isTargetImport : defaultIsTargetImport;
     if (!isFunction(isTargetImport)) { throw new Error(`Expected isTargetImport to be a filter function if given, got: ${ isTargetImport }`); }

--- a/src/lib/cli/sharedTypes.ts
+++ b/src/lib/cli/sharedTypes.ts
@@ -2,31 +2,32 @@ import { Merge } from "ts-toolbelt/out/Union/Merge";
 import { Import } from "../resolveDependencies/identifyImports";
 import { Usage } from "../findUsages/findUsages";
 
-export type MultiTargetModuleOrPath = { [targetName: string]: RegExp };
+type Target = string;
+export type MultiTargetModuleOrPath = { [targetName: Target]: RegExp };
 
 type StatsConfigBase = {
-  isIgnoredFile?: RegExp,
-  isTargetModuleOrPath: RegExp | MultiTargetModuleOrPath,
-  isTargetImport?: (imp: Import) => boolean,
-  isValidUsage?: (use: Usage & { type: string }) => boolean,
-  subprojectPath?: string,
+    isIgnoredFile?: RegExp,
+    isTargetModuleOrPath: RegExp | MultiTargetModuleOrPath,
+    isTargetImport?: (imp: Import) => boolean,
+    isValidUsage?: (use: Usage & { type: "homebrew" | Target }) => boolean,
+    subprojectPath?: string,
 };
 
 type ExclusiveConfigPaths = { tsconfigPath?: null, jsconfigPath?: null }
-  | { tsconfigPath: string }
-  | { jsconfigPath: string };
+    | { tsconfigPath: string }
+    | { jsconfigPath: string };
 
 export type StatsConfig = StatsConfigBase & ExclusiveConfigPaths;
 export type ResolvedStatsConfig = Required<Merge<StatsConfig>>;
 
 
 export type UsageStat = {
-  type: string,
-  name: string,
+    type: "homebrew" | Target,
+    name: string,
 
-  imported_from: string,
-  target_node_file: string,
-  usage_file: string,
+    imported_from: string,
+    target_node_file: string,
+    usage_file: string,
 
-  // author: string, // TODO: implement
+    // author: string, // TODO: implement
 };

--- a/src/lib/cli/sharedTypes.ts
+++ b/src/lib/cli/sharedTypes.ts
@@ -2,31 +2,31 @@ import { Merge } from "ts-toolbelt/out/Union/Merge";
 import { Import } from "../resolveDependencies/identifyImports";
 import { Usage } from "../findUsages/findUsages";
 
+export type MultiTargetModuleOrPath = { [targetName: string]: RegExp };
+
 type StatsConfigBase = {
-    isIgnoredFile?: RegExp,
-    isTargetModuleOrPath: RegExp,
-    isTargetImport?: (imp: Import) => boolean,
-    isValidUsage?: (use: Usage & { type: "target" | "homebrew" }) => boolean,
-    subprojectPath?: string,
+  isIgnoredFile?: RegExp,
+  isTargetModuleOrPath: RegExp | MultiTargetModuleOrPath,
+  isTargetImport?: (imp: Import) => boolean,
+  isValidUsage?: (use: Usage & { type: string }) => boolean,
+  subprojectPath?: string,
 };
 
 type ExclusiveConfigPaths = { tsconfigPath?: null, jsconfigPath?: null }
-    | { tsconfigPath: string }
-    | { jsconfigPath: string };
+  | { tsconfigPath: string }
+  | { jsconfigPath: string };
 
 export type StatsConfig = StatsConfigBase & ExclusiveConfigPaths;
 export type ResolvedStatsConfig = Required<Merge<StatsConfig>>;
 
 
 export type UsageStat = {
-    type: "target" | "homebrew",
-    name: string,
+  type: string,
+  name: string,
 
-    imported_from: string,
-    target_node_file: string,
-    usage_file: string,
+  imported_from: string,
+  target_node_file: string,
+  usage_file: string,
 
-    // author: string, // TODO: implement
+  // author: string, // TODO: implement
 };
-
-

--- a/src/lib/guards.ts
+++ b/src/lib/guards.ts
@@ -9,7 +9,8 @@ export const atLeastOne = <T>(val: ArrayLike<T>): [T, ...T[]] => {
 
 export type StringKeys<T> = T extends T ? Extract<keyof T, string> : never;
 export const objectKeys = <T>(val: T): StringKeys<T>[] => Object.keys(val) as any;
-export const objectValues = <T>(val: T): (T[StringKeys<T>])[] => objectKeys(val).map(k => val[k]);
+export const objectValues = <T>(val: T): (T[StringKeys<T>])[] => Object.values(val);
+export const objectEntries = <T>(val: T): [StringKeys<T>, T[StringKeys<T>]][] => Object.entries(val) as any;
 
 export type Guard<In, Out extends In> = (val: In) => val is Out;
 
@@ -45,6 +46,7 @@ export const isTypeof = <T extends TypeofResults>(expectedType: T) => (val: unkn
 export const isString = isTypeof("string");
 export const isNumber = isTypeof("number");
 export const isFunction = isTypeof("function");
+export const isObject = isTypeof("object");
 
 type Ctor<T> = (...args: any[]) => T;
 export const isInstanceof = <T>(expected: Ctor<T>) => (val: unknown): val is T => val instanceof expected;

--- a/src/lib/guards.ts
+++ b/src/lib/guards.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { inspect } from "util";
-import { Function, Misc } from "ts-toolbelt";
+import { Any, Function, Misc } from "ts-toolbelt";
 
 export const atLeastOne = <T>(val: ArrayLike<T>): [T, ...T[]] => {
     if (val.length < 1) { throw new Error("Expected at least one value"); }
@@ -47,6 +47,9 @@ export const isString = isTypeof("string");
 export const isNumber = isTypeof("number");
 export const isFunction = isTypeof("function");
 export const isObject = isTypeof("object");
+
+export const isObjectOf = <K extends Any.Key, V>(isKey: Guard<unknown, K>, isValue: Guard<unknown, V>) =>
+    (val: unknown): val is { [P in K]: V } => isObject(val) && objectKeys(val).every(isKey) && objectValues(val).every(isValue);
 
 type Ctor<T> = (...args: any[]) => T;
 export const isInstanceof = <T>(expected: Ctor<T>) => (val: unknown): val is T => val instanceof expected;


### PR DESCRIPTION
Allow config to define multiple targets, so you can adoption patterns of multiple DS/Component Libraries over time.

<img width="707" alt="Screenshot 2022-07-14 at 9 05 53 AM" src="https://user-images.githubusercontent.com/1680390/178989301-fa03babd-036f-4642-8fc5-5179df431c38.png">
.