### PR TITLE
Update the stats output, and miscelanuous fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "task": "yarn prep && node -r ts-node/register/transpile-only ./src/tasks/tasks.ts",
     "cli": "yarn prep && node -r ts-node/register/transpile-only ./src/lib/cli/index.ts",
     "lint": "yarn task lint",
-    "prep": "yarn install --no-audit && node -r ts-node/register/transpile-only src/lib/checkEngine.ts --check-yarn",
+    "prep": "yarn install --no-audit --frozen-lockfile && node -r ts-node/register/transpile-only src/lib/checkEngine.ts --check-yarn",
     "demo-start": "yarn demo-prep && REACT_APP_API_URL=$(terraform -chdir=terraform output -json listener_outputs | jq -r '.api_invoke_url') node -r ts-node/register/transpile-only ./src/demo/run-script.ts start",
     "demo-build": "yarn demo-prep && node -r ts-node/register/transpile-only ./src/demo/run-script.ts build",
     "demo-prep": "yarn task -- build --no-test && yarn install --cwd src/demo",
@@ -51,7 +51,7 @@
     "node-worker-threads-pool": "^1.5.1",
     "semver": "^7.3.5",
     "sql.js": "^1.6.2",
-    "ts-morph": "^14.0.0",
+    "ts-morph": "17.0.1",
     "tslib": "^2.4.0",
     "typescript": "^4.5.4",
     "yargs": "^17.3.1"

--- a/src/lambda/worker/handler.ts
+++ b/src/lambda/worker/handler.ts
@@ -97,7 +97,11 @@ export const createHandler = (
         // TSConfig is a .json file, but it's not a json — e.g. it allows comments and `extends` references.
         const memoFsHost = new InMemoryFileSystemHost();
         allFiles.filter(f => f.endsWith(".json")).map(f => memoFsHost.writeFileSync(f, readFile(cloneFs, f)));
-        const tsconfigResolutionFs = new TransactionalFileSystem(memoFsHost);
+        const tsconfigResolutionFs = new TransactionalFileSystem({
+            fileSystem: memoFsHost,
+            skipLoadingLibFiles: true,
+            libFolderPath: undefined,
+        });
         return new TsConfigResolver(tsconfigResolutionFs, tsconfigResolutionFs.getStandardizedAbsolutePath(tsconfigPath), "utf8")
             .getCompilerOptions();
     };

--- a/src/lambda/worker/yarn.lock
+++ b/src/lambda/worker/yarn.lock
@@ -899,13 +899,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@ts-morph/common@~0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.13.0.tgz#77dea1565baaf002d1bc2c20e05d1fb3349008a9"
-  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
+"@ts-morph/common@~0.18.0":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.18.1.tgz#ca40c3a62c3f9e17142e0af42633ad63efbae0ec"
+  integrity sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==
   dependencies:
-    fast-glob "^3.2.11"
-    minimatch "^5.0.1"
+    fast-glob "^3.2.12"
+    minimatch "^5.1.0"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
@@ -1009,12 +1009,10 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-code-block-writer@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.0.tgz#5956fb186617f6740e2c3257757fea79315dd7d4"
-  integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
-  dependencies:
-    tslib "2.3.1"
+code-block-writer@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.3.tgz#9eec2993edfb79bfae845fbc093758c0a0b73b76"
+  integrity sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1078,10 +1076,10 @@ exit-on-epipe@~1.0.1:
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
   integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
-fast-glob@^3.2.11:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1258,10 +1256,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+minimatch@^5.1.0:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -1347,7 +1345,8 @@ radius-tracker@../../../build:
     node-worker-threads-pool "^1.5.1"
     semver "^7.3.5"
     sql.js "^1.6.2"
-    ts-morph "^14.0.0"
+    ts-morph "17.0.1"
+    tslib "^2.4.0"
     typescript "^4.5.4"
     yargs "^17.3.1"
 
@@ -1456,23 +1455,28 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-morph@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-14.0.0.tgz#6bffb7e4584cf6a9aebce2066bf4258e1d03f9fa"
-  integrity sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==
+ts-morph@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-17.0.1.tgz#d85df4fcf9a1fcda1b331d52c00655f381c932d1"
+  integrity sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==
   dependencies:
-    "@ts-morph/common" "~0.13.0"
-    code-block-writer "^11.0.0"
-
-tslib@2.3.1, tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+    "@ts-morph/common" "~0.18.0"
+    code-block-writer "^11.0.3"
 
 tslib@^1.11.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 typescript@^4.5.4:
   version "4.6.3"

--- a/src/lib/checkEngine.ts
+++ b/src/lib/checkEngine.ts
@@ -1,13 +1,8 @@
 import { satisfies } from "semver";
+import { requiredNodeVersion } from "./packageInfo";
 
-const getPkg = () => {
-    try { return require("../package.json"); } // In build
-    catch (_ignore) { return require("../../package.json"); } // In dev
-};
-const requiredVersion = getPkg().engines.node;
-
-if (!satisfies(process.version, requiredVersion)) {
-    throw new Error(`Unsupported Node version. Expected ${ requiredVersion }, got ${ process.version }`);
+if (!satisfies(process.version, requiredNodeVersion)) {
+    throw new Error(`Unsupported Node version. Expected ${ requiredNodeVersion }, got ${ process.version }`);
 }
 
 const hasCheckYarnFlag = process.argv.includes("--check-yarn");

--- a/src/lib/cli/inplace/index.ts
+++ b/src/lib/cli/inplace/index.ts
@@ -47,14 +47,15 @@ export default defineYargsModule(
             isIgnoredFile: args.ignoredFileRe ? new RegExp(args.ignoredFileRe) : undefined,
         };
 
-        const stats = await processStats([{ projectName: args.path ?? "Current directory", stats: [{
+        const config = resolveStatsConfig(unresolvedConfig);
+        const stats = await processStats([{ projectName: args.path ?? "Current directory", config, stats: [{
             commit: {
                 oid: "latest",
                 weeksAgo: 0,
                 ts: new Date(),
                 expectedDate: new Date(),
             },
-            stats: await collectStats(resolveStatsConfig(unresolvedConfig), tag, resolve(args.path ?? process.cwd())),
+            stats: await collectStats(config, tag, resolve(args.path ?? process.cwd())),
         }] }]);
 
         const outfile = resolve(args.outfile || join(process.cwd(), "usages.sqlite"));

--- a/src/lib/cli/sharedTypes.ts
+++ b/src/lib/cli/sharedTypes.ts
@@ -9,7 +9,7 @@ type StatsConfigBase = {
     isIgnoredFile?: RegExp,
     isTargetModuleOrPath: RegExp | MultiTargetModuleOrPath,
     isTargetImport?: (imp: Import) => boolean,
-    isValidUsage?: (use: Usage & { type: "homebrew" | Target }) => boolean,
+    isValidUsage?: (use: Usage & { source: "homebrew" | Target }) => boolean,
     subprojectPath?: string,
 };
 
@@ -22,8 +22,9 @@ export type ResolvedStatsConfig = Required<Merge<StatsConfig>>;
 
 
 export type UsageStat = {
-    type: "homebrew" | Target,
-    name: string,
+    source: "homebrew" | Target,
+
+    component_name: string,
 
     imported_from: string,
     target_node_file: string,

--- a/src/lib/cli/test/grafana_samples.ts
+++ b/src/lib/cli/test/grafana_samples.ts
@@ -1,0 +1,457 @@
+import { WorkerConfig } from "../timelines/workerTypes";
+
+// The config in this file describes grafana ecosystem, found to the best of my ability.
+// It is used to test the Tracker end-to-end, and generate the sample report.
+
+const targets = {
+    grafana: /^@grafana\/ui(?!.*\.s?css$)/,
+    ant: /^(antd|@ant-design)/,
+    mui: /^(@mui|@material-ui)/,
+    chakra: /^chakra-ui/,
+    headlessui: /^@headlessui/,
+    bootstrap: /^react-bootstrap/,
+    visx: /^@visx/,
+    spectrum: /^@adobe\/react-spectrum/,
+    "iot-app-kit": /^@iot-app-kit/,
+    nivo: /^@nivo/,
+    primereact: /^primereact/,
+    rc: /^rc-/, // https://react-component.github.io/
+    reactstrap: /^reactstrap/,
+};
+
+const maxWeeks = 52 * 5;
+const samples: WorkerConfig[] = [ // TODO: specify ts/js configs explicitly where necessary
+    {
+        repoUrl: "https://github.com/grafana/grafana.git",
+        subprojectPath: "/",
+        isTargetModuleOrPath: {
+            ...targets,
+            grafana: /((^@grafana\/ui)|(\/packages\/grafana-ui))(?!.*\.scss$)/, // @grafana/ui or /packages/grafana-ui
+        },
+        maxWeeks: maxWeeks,
+    },
+    {
+        repoUrl: "https://github.com/percona/grafana-dashboards.git",
+        subprojectPath: "/pmm-app",
+        isTargetModuleOrPath: targets,
+        maxWeeks: Math.min(230, maxWeeks), // TODO: there's no `pmm-app` folder before then
+    },
+
+    // Github code search for `in:file+path:/+filename:package.json+grafana+ui+NOT+datasource`
+    // Having `@grafana/ui` in package.json
+    ...[
+        "2664551618/iac-mixgraph-panel",
+        // "ACE-IoT-Solutions/ace-svg-react", Duplicate
+        "Aris-1712/grafan-plugin",
+        "Armalon/GiphySearcherPanelPlugin",
+        "AutohomeCorp/autohome-compareQueries-datasource",
+        "Betula-L/grafana-starter-panel",
+        "Bujupah/grafana-smart-map",
+        "CarlosGallardo97/grafana-echarts-clock-panel",
+        "Chipazawra/v-8-1-c-cluster-live-telemetry-plugin",
+        "CopperHill-Consulting/grafana-chartjs-panel",
+        "CopperHill-Consulting/grafana-customTables-panel",
+        "CorpGlory/grafana-panel-react-ts-webpack-template",
+        "Dalvany/dalvany-image-app",
+        // "Dalvany/dalvany-image-panel", Duplicate
+        "DarminZ/grafana-panel-pulgin",
+        "DavidMarom/grafana-plugin",
+        "Enapter/telemetry-grafana-datasource-plugin",
+        "Exsensio-Ltd/OEEGrafanaVisualizer",
+        "Fondus/Grafana-JsonPretty-Panel",
+        "G-Core/cdn-stats-datasource-plugin",
+        "GMaykode/zfana",
+        "Genius-pig/iotdb",
+        "GlobalNOC/globalnoc-worldview-panel",
+        // "Gowee/traceroute-map-panel", Duplicate
+        // "IntegrationMatters/integrationmatters-comparison-panel", Duplicate
+        "IntegrationMatters/integrationmatters-history-panel",
+        "IntegrationMatters/integrationmatters-spot-panel",
+        "IsmaelMasharo/sankey-panel",
+        "JacquesUys-Hartree/grafana-panel",
+        "JacquesUys-Hartree/grafana-ui-ts",
+        // "JeanBaptisteWATENBERG/grafana-percent-plus", Duplicate
+        "KWMSys/GrafanaPlaceholder",
+        "KWMSys/GrafanaSensorDataSource",
+        "KnightMode/spikeGrafanaPlugin",
+        // "LucasArona/larona-epict-panel", Duplicate
+        "LukasPatzke/grafana-direction-panel",
+        "MAFRUHA-LEAVIN/Grafana-React",
+        "MKortmann/Grafana-Plugins",
+        "MackoLysy/Grafana-Bazel",
+        // "MacroPower/macropower-analytics-panel", Duplicate
+        "MaheshKhanal/netsage-react-bumpchart",
+        // "Maisy/grafana-plugin-test", Removed or private repo
+        "Maniarr/grafana-warp10-backend",
+        // "NatelEnergy/grafana-discrete-panel", Duplicate
+        // "OpenNMS/opennms-helm", Duplicate
+        "RAM92/grafana-mui-5-panel-issue",
+        // "RedisGrafana/grafana-redis-app", Duplicate
+        // "RedisGrafana/grafana-redis-explorer", Duplicate
+        // "SSKGo/perfcurve-panel", Duplicate
+        "Satishpal93/new_design",
+        "Server-Eye/grafana-plugin",
+        "ShamefulOdin31/dummy-plugin",
+        "ShayMoshe/grafana-mapbox-panel-plugin",
+        "SilkeDH/es-plotly-histogram",
+        // "TobiasI2001/TrafficLightsRevival", Removed or private repo
+        "VolkovLabs/volkovlabs-abc-app",
+        "VolkovLabs/volkovlabs-abc-panel",
+        // "VolkovLabs/volkovlabs-image-panel", Duplicate
+        "Vunet-Systems/Insight-Card-Panel",
+        "Vunet-Systems/Matrix-Visualization",
+        "Vunet-Systems/color-table",
+        "WebDevelopUa/grafana-panel-plugin",
+        "Webbeh/edelblack-mqtt-panel",
+        "Yash2017/final",
+        "ae3e/ae3e-html-panel",
+        // "ae3e/ae3e-plotly-panel", Duplicate
+        "akenza-io/gf-grafana-connector",
+        "akenza-io/grafana-connector",
+        "akenza-io/grafana-connector-v3",
+        "alefranklin/grafana-plugin-test",
+        // "alexandrainst/alexandra-trackmap-panel", Duplicate
+        // "algenty/grafana-flowcharting", Duplicate
+        "ampx/grafana-json-button",
+        "apnaremi/grafanatest",
+        // "arkazantsev8/grafana-react-echarts-panel", Removed or private repo
+        // "arkazantsev8/grafana-react-table", Removed or private repo
+        "arrisde/map-select-panel",
+        "asukaji/my-grafana-plugin",
+        "atosorigin/grafana-weathermap-panel",
+        // "auxmoney/grafana-waterfall-panel", Duplicate
+        "baltop/grafana-starter",
+        "basraven/kafka-d3",
+        "benmizrahi/super-bigquery-plugin",
+        "bkurtz/grafana-map-panel",
+        // "boazreicher/mosaic-plot", Duplicate
+        // "boazreicher/sierra-plot", Duplicate
+        "bureau14/qdb-grafana-plugin",
+        "cagrafana/ca-grafana-hierarchy",
+        "chartwerk/grafana-chartwerk-app",
+        // "cloudspout/cloudspout-button-panel", Duplicate
+        "connectall/connectall-grafana-hierarchy",
+        "coolxv/live-streams-panel",
+        "cozzyd/interposcatter",
+        "crystaldust/github-profile-plugin",
+        "danesherbs/carbon-footprint-plugin",
+        "davidraker/VUISetPointPanel",
+        "dbouchierarcad/simple-react-panel",
+        "dev2019zheng/my-grafana-plugin",
+        "diebietse/grafana-mqtt",
+        "dirk-ecker/grafana-timestamp-image-panel",
+        "drbcomua/grafana-map-test",
+        "dwaynebradley/color-skycons-panel",
+        "e-dard/influxdb-iox-grafana",
+        "eaTong/eatong-grafana-biz",
+        "eabaci/panel-template-plugin",
+        "easy-global-market/grafana-ngsild-plugin",
+        "edgedb/edgedb-grafana-frontend",
+        "elabpro/dataops-grafana-qr",
+        "enricotuzzafincons/UseCaseTable",
+        "ertis-research/digital-twins-plugin-for-Grafana",
+        "ertis-research/unity-plugin-for-Grafana",
+        "eswestra/HeatSeries",
+        // "eyousefifar/grafana-datasource-plugin-tutorial", Removed or private repo
+        // "factrylabs/untimely-grafana-panel", Duplicate
+        "fcortes/grafana-photo-grid",
+        "fernandoelger/alert-list",
+        "fiammettacannavo/ModuloInterno",
+        // "flant/grafana-statusmap", Duplicate
+        "fmarslan/solr-plugin-grafana",
+        "fongfai/grafana-ui-graph",
+        "freecoop/grafana-echarts-panel",
+        "fusioncharts/grafana-fusionexport",
+        "fw-dev/piechart-panel",
+        "fylip97/Thesis",
+        "ganadara135/liregression",
+        "ganadara135/panalPluginLR",
+        "geeks-r-us/mqtt-panel",
+        "geogo-in/Barchart-grafana-panel-plugin",
+        "geogo-in/Custom-barchart-plugin",
+        "golioth/grafana-websocket-plugin",
+        "gordonturner/gordonturner-external-ip-panel",
+        // "grafana/clock-panel", Duplicate
+        // "grafana/grafana-polystat-panel", Duplicate
+        // "grafana/grafana-sensu-app", // TODO: problem resolving external libs committed to source code
+        // "grafana/grafana-starter-panel", Duplicate
+        "grafana/kentik-app",
+        // "grafana/perspective-panel", Duplicate
+        // "grafana/piechart-panel", Duplicate
+        // "grafana/simple-angular-panel", Not React
+        "hadrianl/highcharts-plugin",
+        // "hai2007/grafana-panel-radar", Removed or private repo
+        "hatlabs/grafana-polar-timeseries",
+        "hslayers/grafana-plugin",
+        "huaweicloud/cloudeye-grafana",
+        "hugoattal/grafana-mongodb-plugin",
+        "icn-team/grafana-topology-plugin",
+        "ifrost/o11ywood",
+        // "innius/grafana-video-panel", Duplicate
+        "io-systems/gersscipal-suivi-now-panel",
+        "io-systems/gersscipal-suivi-opened-time-panel",
+        // "isaozler/grafana-shift-selector", Duplicate
+        // "isaozler/pareto-chart", Duplicate
+        "iuricmp/grafana-iot-map-panel",
+        "jackw/grafana-plugin-federated",
+        "jackw/grafana-test-plugin",
+        "jahzeelamador/Parallel-Aqi",
+        "jayhuynh/bar-chart",
+        "jbguerraz/druid-grafana",
+        // "jdbranham/grafana-diagram", Duplicate
+        "jessin08/advanced-grafana-descrete-panel",
+        "jkmnt/grafana_funcomp",
+        "jkmnt/grafana_vtable",
+        "jkschneider/grafana-trace-exemplars",
+        "justinStoner/grafana-candlestick-chart",
+        "jwood-krg/opennms-helm-backend",
+        "kalidasya/grafana-bundle-plugin-example",
+        // "kaydelaney/grafana-vite", Looks like a clone of grafana with a different build tool
+        "kgonidis/groupedbarchart",
+        "kgonidis/timelessgraph",
+        "kiotlog/kiotlog-beicavie-panel",
+        "knightss27/grafana-network-weathermap",
+        "konradsitarz/grafana-plotly-react-panel",
+        // "korenh/GrafanaBoundingBoxPlugin", Removed or private repo
+        "kpfaulkner/discord-plugin",
+        "kpfaulkner/sendgrid-plugin",
+        "kumaravel29/grafana-sankey-panel",
+        "kundankarna1994/grafana",
+        "lalaux-design/alertmanager-ds",
+        "lapnap/grafana-live-app",
+        "leonardopivetta/Grafana-telemetry-analysis-panel",
+        "manux81/manux81-googlemap-panel",
+        "marcpar/grafana_couchdb",
+        // "marcusolsson/grafana-calendar-panel", Duplicate
+        // "marcusolsson/grafana-hexmap-panel", Duplicate
+        "marcusolsson/grafana-plugin-support",
+        // "marcusolsson/grafana-treemap-panel", Duplicate
+        "mariocapitbrok/gpanel",
+        "mariocapitbrok/grafana-starter-panel",
+        "mav10/grafana-queryimage-panel",
+        // "michaeldmoore/michaeldmoore-scatter-panel", Duplicate
+        // "minhyeong-jang/os-grafana-react", // TODO: problem resolving external libs committed to source code
+        "mure/grafana-options-bug",
+        "narang99/grafana-plugin-tutorial",
+        "nehal119/arcgis-grafana-plugin",
+        "netsage-project/Netsage-Navigation",
+        "netsage-project/netsage-bumpchart-panel",
+        // "netsage-project/netsage-sankey-panel", Duplicate
+        "netsage-project/react-slope-graph",
+        "nicfv/Psychart",
+        "nick-enoent/dsosds",
+        "niechao136/panel",
+        "ooasis/annotation-backend-plugin",
+        "ooasis/gitlab-data-source-plugin",
+        "ooasis/rally-data-source-plugin",
+        "ooasis/release-view-panel-plugin",
+        "opsramp/opsramp-metrics-datasource",
+        "optimizca/servicenow-grafana",
+        // "orchestracities/iconstat-panel", Duplicate
+        // "orchestracities/map-panel", Duplicate
+        "owbeg/grafana-imageit-panel",
+        "ozonru/data-grid-grafana-plugin",
+        "ozonru/flamegraph-grafana-plugin",
+        "ozonru/graph-grafana-plugin",
+        "ozonru/template-value-grafana-plugin",
+        "percona-platform/saas-ui",
+        "peterholmberg/fan-panel",
+        "pfgithub/pfgithub-multistat-panel",
+        "pgillich/grafana-tree-panel",
+        "philips-labs/grafana-bpm-plugin",
+        "pontus-vision/pontus-grafana-react-panel",
+        "pportelaf/grafana-sensors-floor-plan-panel",
+        "prateekdev92/grafana-status-dot-panel",
+        "predictiveworks/grafana-works",
+        "qianlifeng/taosdata-grafana-plugin",
+        "questdb/grafana-datasource",
+        "quincarter/react-grafana-plugin",
+        "qxang/grafan-plugin",
+        "raguct25/grafana-plugin-react",
+        "rajsameer/alert-manager-table",
+        // "raulsperoni/magnesium-wordcloud-panel", Duplicate
+        "rkorshakevich/zoomable-sunburst",
+        "rnersesian/examplePanel",
+        "rnersesian/test-plugin",
+        "ryantxu/image-viewer-panel",
+        "ryantxu/preso-app",
+        "saterunholy/plugintest",
+        "saterunholy/testrepository",
+        "sbueringer/grafana-consul-datasource",
+        "scc-digitalhub/grafana-dremio-datasource-plugin",
+        "schoentoon/rsge-grafana",
+        "sd2k/grafana-sample-backend-plugin-rust",
+        "seawavezhangdining/xdevt-html-panel",
+        "sergioceron/grafana-map",
+        "shannonlal/shannonlal-grafana-shannonlal-sample-json",
+        // "shintarof/grafana-simple-panelplugin", Removed or private repo
+        "shuangquanhuang/grafana-plugin-template",
+        // "snuids/grafana-radar-panel", Duplicate
+        // "snuids/grafana-svg-panel", Duplicate
+        // "speakyourcode/grafana-button-panel", Duplicate
+        "srclosson/div-panel",
+        "srclosson/geotrack-panel",
+        "srclosson/grafana-tsbackend",
+        "srclosson/validation-panel",
+        "steebnh/westc",
+        "surzycki/grafana-react",
+        "taianesb1994/barchartReactChartjs2",
+        "taianesb1994/grafana-echarts-barcharts",
+        "taianesb1994/piechart2Types-recharts",
+        "tbo47/openglobus_grafana",
+        "tdtan/granfana",
+        "techierishi/graplugin",
+        // "telekom/sebastiangunreben-cdf-plugin", Duplicate
+        "thegreymatter/grafana-agg-table",
+        "thuanguyen1602/grafana-backend-plugin",
+        "thuanguyen1602/grafana-frontend-plugin",
+        "tinybat02/ES-3dscatter",
+        "tinybat02/ES-Bus-Pure",
+        "tinybat02/ES-apex-generic",
+        "tinybat02/ES-bar",
+        "tinybat02/ES-download-csv",
+        "tinybat02/ES-draw-count",
+        "tinybat02/ES-duration-stat",
+        "tinybat02/ES-funnel",
+        "tinybat02/ES-grid-heat",
+        "tinybat02/ES-grid-heat-by-id",
+        "tinybat02/ES-heat-flow",
+        "tinybat02/ES-maptk",
+        "tinybat02/ES-point-latest",
+        "tinybat02/ES-scatter-plot",
+        "tinybat02/ES-tabheat-conf",
+        "tinybat02/Latest_point_line",
+        "tinybat02/Linechart_XY",
+        "tinybat02/Map-polygon",
+        "tinybat02/Scatter-office",
+        "tinybat02/Traj-step-play",
+        "tinybat02/tmp_zip_catch",
+        "tom2kota/grafana-panel-react-ts-webpack-template",
+        "tom2kota/grafana-plugin-fetch-unit-tests",
+        "tom2kota/grafana-starter-panel",
+        "tomastauer/newrelic-grafana-insights",
+        "tomcheney/grafana-vertical-plot",
+        "twei55/grafana-scatterplot",
+        "ui3o/grafana-quick-log-panel",
+        "venkataramu/demo-grafana-plugin",
+        "vertica/vertica-grafana-datasource",
+        "vijayleom/ca-grafana-hierarchy",
+        "vmware-labs/panel-plug-ins-for-grafana",
+        "vsergeyev/aws-kinesis",
+        "vsergeyev/loudml-grafana-app",
+        "vsergeyev/tensorflow-grafana-app",
+        "wildmountainfarms/solarthing-grafana",
+        "world-direct/extrusion-panel-plugin",
+        "world-direct/forecast-input-panel-plugin",
+        "wouterdt/grafana-react-testpanel",
+        "woutervh-/grafana-mapbox",
+        "xformation/xformation-assetmanager-ui-plugin",
+        "xformation/xformation-compliancemanager-ui-plugin",
+        "xformation/xformation-logmanager-ui-plugin",
+        "yesoreyeram/grafana-infinity-panel",
+        "yesoreyeram/grafana-nocode-editor",
+        "yesoreyeram/grafana-slideshow-panel",
+        "yesoreyeram/grafana-utilities",
+        // "yesoreyeram/yesoreyeram-boomtheme-panel", Duplicate
+        "yt-developers/whyit-grafana-gf_plugin.ds.elasticsearch-v7",
+        "zen0fpy/grafana_plugins_demo",
+        "zezking/grafana-panel-plugin-tutorial",
+        "zhangucan/simple-data-filter",
+    ].map(repoRef => ({
+        repoUrl: "https://github.com/" + repoRef,
+        subprojectPath: "/",
+        isTargetModuleOrPath: targets,
+        maxWeeks: maxWeeks,
+    })),
+
+    // Non-deprecated panels & apps from grafana website,
+    // that have available github, aren't already included with grafana,
+    // not archived or deprecated
+    // and mentioning `@grafana/ui` in package.json
+    ...[
+        "https://github.com/anodot/grafana-panel.git",
+        "https://github.com/VolkovLabs/volkovlabs-image-panel.git",
+        "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app.git",
+        "https://github.com/grafana/synthetic-monitoring-app.git",
+        "https://github.com/RedisGrafana/grafana-redis-explorer.git",
+        "https://github.com/RedisGrafana/grafana-redis-app.git",
+        "https://github.com/OpenNMS/opennms-helm.git",
+        "https://github.com/grafana/grafana-iot-twinmaker-app.git",
+        "https://github.com/alexanderzobnin/grafana-zabbix.git",
+        "https://github.com/grafana/clock-panel.git",
+        "https://github.com/raulsperoni/magnesium-wordcloud-panel.git",
+        "https://github.com/lework/grafana-lenav-panel.git",
+        "https://github.com/auxmoney/grafana-waterfall-panel.git",
+        "https://github.com/innius/grafana-video-panel.git",
+        "https://github.com/factrylabs/untimely-grafana-panel.git",
+        "https://github.com/marcusolsson/grafana-treemap-panel.git",
+        "https://github.com/alexandrainst/alexandra-trackmap-panel.git",
+        "https://github.com/Gowee/traceroute-map-panel.git",
+        "https://github.com/WilliamVenner/grafana-timepicker-buttons.git",
+        "https://github.com/flant/grafana-statusmap.git",
+        "https://github.com/boazreicher/sierra-plot.git",
+        "https://github.com/isaozler/grafana-shift-selector.git",
+        "https://github.com/NovatecConsulting/novatec-service-dependency-graph-panel.git",
+        "https://github.com/michaeldmoore/michaeldmoore-scatter-panel.git",
+        "https://github.com/netsage-project/netsage-sankey-panel.git",
+        "https://github.com/snuids/grafana-radar-panel.git",
+        "https://github.com/grafana/grafana-starter-panel.git",
+        // "https://github.com/grafana/grafana-polystat-panel.git", // TODO: problem resolving external libs committed to source code
+        "https://github.com/ae3e/ae3e-plotly-panel.git",
+        "https://github.com/SSKGo/perfcurve-panel.git",
+        "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus.git",
+        "https://github.com/isaozler/pareto-chart.git",
+        "https://github.com/orchestracities/map-panel.git",
+        "https://github.com/orchestracities/iconstat-panel.git",
+        "https://github.com/boazreicher/mosaic-plot.git",
+        "https://github.com/thiagoarrais/grafana-matomo-tracking-panel.git",
+        "https://github.com/flaminggoat/map-track-3-d.git",
+        "https://github.com/pierosavi/pierosavi-imageit-panel.git",
+        "https://github.com/gapitio/gapit-htmlgraphics-panel.git",
+        "https://github.com/marcusolsson/grafana-hourly-heatmap-panel.git",
+        "https://github.com/marcusolsson/grafana-hexmap-panel.git",
+        "https://github.com/grafana/grafana-guidedtour-panel.git",
+        "https://github.com/marcusolsson/grafana-gantt-panel.git",
+        "https://github.com/algenty/grafana-flowcharting.git",
+        "https://github.com/LucasArona/larona-epict-panel.git",
+        "https://github.com/Billiballa/bilibala-echarts-panel.git",
+        "https://github.com/marcusolsson/grafana-dynamictext-panel.git",
+        "https://github.com/Dalvany/dalvany-image-panel.git",
+        "https://github.com/NatelEnergy/grafana-discrete-panel.git",
+        "https://github.com/jdbranham/grafana-diagram.git",
+        "https://github.com/IntegrationMatters/integrationmatters-comparison-panel.git",
+        "https://github.com/snuids/grafana-svg-panel.git",
+        "https://github.com/telekom/sebastiangunreben-cdf-plugin.git",
+        "https://github.com/marcusolsson/grafana-calendar-panel.git",
+        "https://github.com/cloudspout/cloudspout-button-panel.git",
+        "https://github.com/speakyourcode/grafana-button-panel.git",
+        "https://github.com/yesoreyeram/yesoreyeram-boomtheme-panel.git",
+        "https://github.com/MacroPower/macropower-analytics-panel.git",
+        "https://github.com/ACE-IoT-Solutions/ace-svg-react.git",
+        "https://github.com/briangann/grafana-datatable-panel.git",
+    ].map(repoUrl => ({
+        repoUrl,
+        subprojectPath: "/",
+        isTargetModuleOrPath: targets,
+        maxWeeks: maxWeeks,
+    })),
+
+    // "panel" projects in the "grafana" github org
+    // https://github.com/orgs/grafana/repositories?q=panel&type=all&language=&sort=
+    ...[
+        "https://github.com/grafana/piechart-panel",
+        "https://github.com/grafana/perspective-panel",
+        // "https://github.com/grafana/grafana-guidedtour-panel", Already referenced by grafana plugin list
+        // "https://github.com/grafana/grafana-polystat-panel", Already referenced by grafana plugin list
+        // "https://github.com/grafana/clock-panel", Already referenced by grafana plugin list
+        "https://github.com/grafana/singlestat-panel",
+        // "https://github.com/grafana/grafana-starter-panel", Already referenced by grafana plugin list
+    ].map(repoUrl => ({
+        repoUrl: repoUrl + ".git",
+        subprojectPath: "/",
+        isTargetModuleOrPath: targets,
+        maxWeeks: maxWeeks,
+    })),
+];
+
+export default samples;

--- a/src/lib/cli/timelines/concurrentQueue.spec.ts
+++ b/src/lib/cli/timelines/concurrentQueue.spec.ts
@@ -1,0 +1,66 @@
+import { concurrentQueue } from "./concurrentQueue";
+
+describe("Concurrent Queue", () => {
+    const deferred = (): { promise: Promise<void>, res: () => void } => {
+        let res: null | (() => void) = null;
+        const promise = new Promise<void>(r => { res = r; });
+
+        if (!res) { throw new Error("Implementation error: could not grab resolve function"); }
+        return { promise, res };
+    };
+
+    it("should return results in order of task definition, even if tasks complete out of sequence", async () => {
+        const range = [...Array(10).keys()];
+        const tasks = range.map(i => () => new Promise(r => setTimeout(
+            () => r(i),
+            Math.round(Math.random()) + 1, // Resolve in 1 or 2ms
+        )));
+        const res = await concurrentQueue(Infinity, tasks, x => x());
+        expect(res).toEqual(range);
+    });
+
+    it("should limit the number of tasks running concurrently", async () => {
+        const range = [...Array(5).keys()];
+        const deferreds = range.map(deferred);
+        const tasks = range.map(i => jest.fn().mockImplementation(() => {
+            const d = deferreds[i];
+            if (!d) { throw new Error("Ranges mismatch"); }
+            return d.promise;
+        }));
+
+        const res = concurrentQueue(2, tasks, x => x());
+
+        expect(tasks[0]).toHaveBeenCalled();
+        expect(tasks[1]).toHaveBeenCalled();
+        expect(tasks[2]).not.toHaveBeenCalled();
+        expect(tasks[3]).not.toHaveBeenCalled();
+        expect(tasks[4]).not.toHaveBeenCalled();
+
+        deferreds[1]?.res(); // Resolve 2nd task
+        await deferreds[1]?.promise;
+        expect(tasks[0]).toHaveBeenCalled();
+        expect(tasks[1]).toHaveBeenCalled();
+        expect(tasks[2]).toHaveBeenCalled();
+        expect(tasks[3]).not.toHaveBeenCalled();
+        expect(tasks[4]).not.toHaveBeenCalled();
+
+        deferreds[2]?.res(); // Resolve 3rd task
+        await deferreds[2]?.promise;
+        expect(tasks[0]).toHaveBeenCalled();
+        expect(tasks[1]).toHaveBeenCalled();
+        expect(tasks[2]).toHaveBeenCalled();
+        expect(tasks[3]).toHaveBeenCalled();
+        expect(tasks[4]).not.toHaveBeenCalled();
+
+        deferreds[0]?.res(); // Resolve 1st task
+        await deferreds[0]?.promise;
+        expect(tasks[0]).toHaveBeenCalled();
+        expect(tasks[1]).toHaveBeenCalled();
+        expect(tasks[2]).toHaveBeenCalled();
+        expect(tasks[3]).toHaveBeenCalled();
+        expect(tasks[4]).toHaveBeenCalled();
+
+        deferreds.slice(3).forEach(x => x.res()); // Resolve remaining deferreds
+        await res; // Handle error if any
+    });
+});

--- a/src/lib/cli/timelines/concurrentQueue.ts
+++ b/src/lib/cli/timelines/concurrentQueue.ts
@@ -1,0 +1,34 @@
+export const concurrentQueue = <T, R>(limit: number, items: ReadonlyArray<T>, process: (val: T) => Promise<R>): Promise<R[]> => {
+    function* init() {
+        for (const item of items) {
+            yield process(item);
+        }
+    }
+
+    const iterator = init();
+
+    let inflight = 0;
+    let processed = 0;
+    const results: R[] = [];
+    const resume = async (): Promise<void> => {
+        const batch = [];
+        while (inflight < limit) {
+            const itemIdx = processed;
+            processed += 1;
+            inflight += 1;
+
+            const step = iterator.next();
+            if (step.done) { break; }
+
+            batch.push(step.value.then(x => {
+                results[itemIdx] = x; // Save preserving order
+                inflight -= 1;
+                return resume();
+            }));
+        }
+
+        await Promise.all(batch);
+    };
+
+    return resume().then(() => results);
+};

--- a/src/lib/cli/timelines/getTimelineForOneRepo.ts
+++ b/src/lib/cli/timelines/getTimelineForOneRepo.ts
@@ -13,7 +13,7 @@ import { setupWorkerPool } from "./workerPool";
 import { unexpected } from "../../guards";
 import { UsageStat } from "../sharedTypes";
 
-export const getTimelineForOneRepo = async (cacheDir: string, config: ResolvedWorkerConfig, workerPool: ReturnType<typeof setupWorkerPool>): Promise<Stats> => {
+export const getTimelineForOneRepo = async (cacheDir: string, config: ResolvedWorkerConfig, workerPool: ReturnType<typeof setupWorkerPool>["pool"]): Promise<Stats> => {
     const cloneSince = new Date();
     cloneSince.setDate(cloneSince.getDate() - (config.maxWeeks + 1) * 7);
 

--- a/src/lib/cli/timelines/workerPool.ts
+++ b/src/lib/cli/timelines/workerPool.ts
@@ -22,10 +22,13 @@ export const setupWorkerPool = () => {
     const workerFileBase = join(__dirname, "statsWorker");
     const workerFile = workerFileBase + (statSync(workerFileBase + ".ts", { throwIfNoEntry: false })?.isFile() ? ".ts" : ".js");
 
-    return new StaticPool({
+    return {
+        pool: new StaticPool({
+            size: numWorkers,
+            task: workerFile,
+            resourceLimits: { maxOldGenerationSizeMb: desiredMemory / 1024 },
+        }),
         size: numWorkers,
-        task: workerFile,
-        resourceLimits: { maxOldGenerationSizeMb: desiredMemory / 1024 },
-    });
+    };
 };
 

--- a/src/lib/cli/util/cache.ts
+++ b/src/lib/cli/util/cache.ts
@@ -22,7 +22,7 @@ const cacheConfigKeys: { [P in StringKeys<CacheConfig>]-?: null } = {
     jsconfigPath: null,
 };
 
-const version = 1;
+const version = 2;
 export const cacheFileName = (config: CacheConfig) => {
     const configHash = md5(JSON.stringify(
         objectKeys(config).filter(k => k in cacheConfigKeys).reduce((_obj, k) => {

--- a/src/lib/cli/util/stats.ts
+++ b/src/lib/cli/util/stats.ts
@@ -32,8 +32,8 @@ export function usageDistributionAcrossFileTree(usages: UsageStat[]): string {
 
 export function componentUsageDistribution(usages: UsageStat[]) {
     const usageCounts = usages.reduce((agg, u) => {
-        const usage = agg[u.name] ?? 0;
-        agg[u.name] = usage + 1;
+        const usage = agg[u.component_name] ?? 0;
+        agg[u.component_name] = usage + 1;
         return agg;
     }, {} as { [name: string]: number });
 

--- a/src/lib/packageInfo.ts
+++ b/src/lib/packageInfo.ts
@@ -1,0 +1,8 @@
+const getPkg = () => {
+    try { return require("../package.json"); } // In build
+    catch (_ignore) { return require("../../package.json"); } // In dev
+};
+
+const packageJson = getPkg();
+export const version: string = packageJson.version;
+export const requiredNodeVersion: string = packageJson.engines.node;

--- a/src/lib/resolveDependencies/identifyExports.spec.ts
+++ b/src/lib/resolveDependencies/identifyExports.spec.ts
@@ -190,6 +190,16 @@ describe("Identify exports", () => {
         expect(exports).toHaveLength(0);
     });
 
+    it("should not return duplicate typescript type exports", async () => {
+        const exports = identifyExports(project.createSourceFile("tst.js", `
+            export interface Something { label: Label; }
+            export interface Label { col: number; }
+            export interface Label { row: number; }
+        `));
+
+        expect(exports).toHaveLength(0);
+    });
+
     it("should correctly process export referenced multiple times throughout the file", async () => {
         const exports = identifyExports(project.createSourceFile("tst.js", `
             export function tst() {}

--- a/src/lib/resolveDependencies/identifyExports.ts
+++ b/src/lib/resolveDependencies/identifyExports.ts
@@ -71,7 +71,8 @@ function findExportedDeclaration(symbol: TSSymbol, file: SourceFile) {
     const declarations = symbol.getDeclarations()
         .filter(declaration => isExportOrExportable(declaration) || declaration.getAncestors().some(isExportOrExportable))
         .filter(declaration => declaration.getSourceFile() === file)
-        .filter(declaration => !Node.isFunctionDeclaration(declaration) || declaration.hasBody());
+        .filter(declaration => !Node.isFunctionDeclaration(declaration) || declaration.hasBody())
+        .filter(declaration => !Node.isInterfaceDeclaration(declaration) && !Node.isTypeAliasDeclaration(declaration)); // Ignore types and interfaces
 
     if (declarations.length === 0) { return null; }
     if (declarations.length > 1) {

--- a/src/lib/resolveDependencies/identifyImports.spec.ts
+++ b/src/lib/resolveDependencies/identifyImports.spec.ts
@@ -86,7 +86,9 @@ describe("Identify imports", () => {
         expect(warnings).toHaveLength(1);
 
         const [warning] = atLeastOne(warnings);
-        expect(warning).toHaveProperty("type", "import-unresolved-module-specifier");
+        if (warning.type !== "import-unresolved-module-specifier") {
+            throw new Error(`Expected an import-unresolved-module-specifier warning, got ${ warning.type } instead`);
+        }
         expect(Node.isIdentifier(warning.moduleSpecifier)).toBe(true);
         expect(warning.moduleSpecifier.getText()).toBe("mod");
     });
@@ -106,7 +108,7 @@ describe("Identify imports", () => {
         expect(imp.importCall.getText()).toBe("import(\"module\")");
     });
 
-    it("should throw if dynamic import is used without string module identifier", async () => {
+    it("should warn if dynamic import is used without string module identifier", async () => {
         const { warnings } = identifyImports(project.createSourceFile("tst.js", `
             async function tst() {
                 const mod = "module"; 
@@ -117,9 +119,25 @@ describe("Identify imports", () => {
         expect(warnings).toHaveLength(1);
 
         const [warning] = atLeastOne(warnings);
-        expect(warning).toHaveProperty("type", "import-unresolved-module-specifier");
+        if (warning.type !== "import-unresolved-module-specifier") {
+            throw new Error(`Expected an import-unresolved-module-specifier warning, got ${ warning.type } instead`);
+        }
         expect(Node.isIdentifier(warning.moduleSpecifier)).toBe(true);
         expect(warning.moduleSpecifier.getText()).toBe("mod");
+    });
+
+    it("should warn if import equals is used without referencing an external module", async () => {
+        const { warnings } = identifyImports(project.createSourceFile("tst.js", `
+            import IRichLanguageConfiguration = monaco.languages.LanguageConfiguration
+        `));
+
+        expect(warnings).toHaveLength(1);
+
+        const [warning] = atLeastOne(warnings);
+        if (warning.type !== "import-unresolved-import-equals-definition") {
+            throw new Error(`Expected an import-unresolved-module-specifier warning, got ${ warning.type } instead`);
+        }
+        expect(warning.imported.getText()).toBe("monaco.languages.LanguageConfiguration");
     });
 
     it("should detect cjs require imports", async () => {
@@ -144,7 +162,9 @@ describe("Identify imports", () => {
         expect(warnings).toHaveLength(1);
 
         const [warning] = atLeastOne(warnings);
-        expect(warning).toHaveProperty("type", "import-unresolved-module-specifier");
+        if (warning.type !== "import-unresolved-module-specifier") {
+            throw new Error(`Expected an import-unresolved-module-specifier warning, got ${ warning.type } instead`);
+        }
         expect(Node.isIdentifier(warning.moduleSpecifier)).toBe(true);
         expect(warning.moduleSpecifier.getText()).toBe("mod");
     });

--- a/src/lib/resolveModule/resolveModule.spec.ts
+++ b/src/lib/resolveModule/resolveModule.spec.ts
@@ -82,4 +82,26 @@ describe("Resolve module", () => {
         const res = resolveModule("./target.js", "dependant.js");
         expect(res).toHaveProperty("type", "module-resolution");
     });
+
+    it("should warn if a file that exists on the filesystem is excluded from project sources", async () => {
+        project.getFileSystem().writeFileSync("./file.js", "");
+
+        project.createSourceFile("dependant.js", `
+            import * from "./file.js";
+        `);
+
+        const res = resolveModule("./file.js", "dependant.js");
+        expect(res).toHaveProperty("type", "module-resolution");
+    });
+
+    it("should return null for a resolved file of an unsupported format", async () => {
+        project.getFileSystem().writeFileSync("./file.png", "");
+
+        project.createSourceFile("dependant.js", `
+            import url from "./file.png";
+        `);
+
+        const res = resolveModule("./file.png", "dependant.js");
+        expect(res).toBe(null);
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,13 +1708,13 @@
   resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@ts-morph/common@~0.13.0":
-  version "0.13.0"
-  resolved "https://registry.npmjs.org/@ts-morph/common/-/common-0.13.0.tgz"
-  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
+"@ts-morph/common@~0.18.0":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.18.1.tgz#ca40c3a62c3f9e17142e0af42633ad63efbae0ec"
+  integrity sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==
   dependencies:
-    fast-glob "^3.2.11"
-    minimatch "^5.0.1"
+    fast-glob "^3.2.12"
+    minimatch "^5.1.0"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
@@ -3271,12 +3271,10 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-code-block-writer@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.0.tgz"
-  integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
-  dependencies:
-    tslib "2.3.1"
+code-block-writer@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.3.tgz#9eec2993edfb79bfae845fbc093758c0a0b73b76"
+  integrity sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -4723,6 +4721,17 @@ fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6956,10 +6965,17 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@5.0.1, minimatch@^5.0.1:
+minimatch@5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz"
   integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^5.1.0:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -9612,13 +9628,13 @@ tryer@^1.0.1:
   resolved "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-morph@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/ts-morph/-/ts-morph-14.0.0.tgz"
-  integrity sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==
+ts-morph@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-17.0.1.tgz#d85df4fcf9a1fcda1b331d52c00655f381c932d1"
+  integrity sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==
   dependencies:
-    "@ts-morph/common" "~0.13.0"
-    code-block-writer "^11.0.0"
+    "@ts-morph/common" "~0.18.0"
+    code-block-writer "^11.0.3"
 
 ts-node@^10.5.0:
   version "10.7.0"
@@ -9654,15 +9670,15 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.3.1, tslib@^2.0.3, tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.3, tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Changes to stats output:
* separated sources from usages to their own table
* included metadata, like schema version, package version, and creation time
* deduplicated components from same source when used across various projects

Other changes:
* Upgraded ts-morph version
* Added the grafana samples config to re-generate sample report data
* Resolved issues running tracker against grafana samples
* Limited concurrency of timeline processing for multi-project setups to spread the initial burst of network activity
* Fixed the issue when shallow git-fetch didn't have enough info to reconstruct the repo