### PR TITLE
Warn on missing subproject path

### DIFF
--- a/src/lib/cli/timelines/workerTypes.ts
+++ b/src/lib/cli/timelines/workerTypes.ts
@@ -1,6 +1,7 @@
 import { Primitive } from "ts-toolbelt/out/Misc/Primitive";
 import { StatsConfig, UsageStat } from "../sharedTypes";
 import { Merge } from "ts-toolbelt/out/Union/Merge";
+import { Warning } from "../collectStats";
 
 const maxWeeksKey = "maxWeeks";
 type DurationConfig = { [maxWeeksKey]: number } | { since: Date };
@@ -10,7 +11,7 @@ export type WorkerConfig = StatsConfig & DurationConfig & {
 };
 export type ResolvedWorkerConfig = Omit<Required<Merge<WorkerConfig>>, typeof maxWeeksKey>;
 
-export type WorkerSuccessResponse = { status: "result", result: UsageStat[] };
+export type WorkerSuccessResponse = { status: "result", result: UsageStat[], warnings: Warning[] };
 export type WorkerFailureResponse = { status: "error", error: unknown };
 export type WorkerResponse = WorkerSuccessResponse | WorkerFailureResponse;
 export type WorkerPayload = { config: ResolvedWorkerConfig, commit: string, cacheDir: string };
@@ -40,4 +41,4 @@ export type JsonOf<T> = T extends Exclude<Primitive, symbol | undefined> ? T
     : { [P in keyof T]: JsonOf<T[P]> };
 
 export type CommitData = { oid: string, ts: Date, weeksAgo: number, expectedDate: Date };
-export type Stats = { commit: CommitData, stats: UsageStat[] }[];
+export type Stats = { commit: CommitData, stats: UsageStat[], warnings: Warning[] }[];

--- a/src/lib/cli/util/cacheVersion.ts
+++ b/src/lib/cli/util/cacheVersion.ts
@@ -1,1 +1,1 @@
-export const cacheVersion = 4;
+export const cacheVersion = 5;

--- a/src/lib/findUsages/findUsages.ts
+++ b/src/lib/findUsages/findUsages.ts
@@ -233,7 +233,7 @@ const isReferenceUsage = (node: Node, warn: Warn): boolean => {
     if (Node.isJsxSpreadAttribute(parent)) { return true; }
     if (Node.isAsExpression(parent)) { return true; }
     if (Node.isBindingElement(parent)) { return true; }
-    if (Node.isNewExpression(parent)) { return true; } // TODO: test: Identifier 'JsonExplorer' in 'const jsonExp = new JsonExplorer(jsonObject, expansionLevel, { animateOpen: true });'
+    if (Node.isNewExpression(parent)) { return true; }
 
     warn({
         type: "find-usage-unhandled-node-type",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,7 @@
+import { FindUsageWarning } from "./findUsages/findUsages";
+import { ImportWarning } from "./resolveDependencies/identifyImports";
+import { DependencyResolutionWarning } from "./resolveDependencies/resolveDependencies";
+
 export * as tsMorph from "ts-morph"; // Re-export ts-morph, so that the consumers run exactly the same version
 export * as tsMorphCommon from "@ts-morph/common"; // Re-export @ts-morph/common, so that the consumers run exactly the same version
 
@@ -45,6 +49,8 @@ export type {
     FindUsages,
     FindUsageWarning,
 } from "./findUsages/findUsages";
+
+export type Warning = FindUsageWarning | ImportWarning | DependencyResolutionWarning;
 
 export {
     getImportNode,

--- a/src/lib/resolveModule/resolveModule.ts
+++ b/src/lib/resolveModule/resolveModule.ts
@@ -3,10 +3,10 @@ import { SUPPORTED_FILE_TYPES } from "../supportedFileTypes";
 import { hasProp } from "../guards";
 
 export type ResolveModule = (moduleName: string, containingFile: string) => SourceFile | ModuleResolutionWarning | null;
-export type ModuleResolutionWarning = { type: "module-resolution", message: string };
+const moduleResolutionType = "module-resolution";
+export type ModuleResolutionWarning = { type: typeof moduleResolutionType, message: string };
 
 const hasType = hasProp("type");
-const moduleResolutionType: ModuleResolutionWarning["type"] = "module-resolution";
 export const isModuleResolutionWarning = (val: unknown): val is ModuleResolutionWarning => hasType(val) && val.type === moduleResolutionType;
 
 export const setupModuleResolution = (project: Project, cwd: string): ResolveModule => {


### PR DESCRIPTION
Also fail if subproject path is missing in the entire processed timeline of a repo.