### PR TITLE
Extract domReferenceFactories into config options

### DIFF
--- a/src/docs/pages/configuration_file.md
+++ b/src/docs/pages/configuration_file.md
@@ -48,6 +48,14 @@ export default [
         //            Defaults to "/"
         subprojectPath: "/",
 
+        // [optional] Regexp testing if an import path comes from a library
+        //            that wraps built-in JSX elements, e.g. `styled.div`.
+        //            This is used for detecting custom components implemented
+        //            using such libraries.
+        domReferenceFactories: {
+            "styled-components": /styled-components/,
+        },
+
         // [optional] Regexp specifying which file paths to exclude.
         //            See the document below for the default value & details.
         isIgnoredFile: /\/node_modules\//,

--- a/src/lib/cli/collectStats.ts
+++ b/src/lib/cli/collectStats.ts
@@ -168,11 +168,7 @@ export async function collectStats(
         return targetUsages;
     });
 
-
-    const domReferenceFactories: ReadonlyArray<{ name: string, re: RegExp }> = [
-        { name: "styled-components", re: /styled-components/ },
-        { name: "stitches", re: /^@stitches/ },
-    ];
+    const domReferenceFactories = objectEntries(config.domReferenceFactories).map(([name, re]) => ({ name, re }));
     const factoryDomReferences = domReferenceFactories
         .map(f => {
             const detections = dependencies

--- a/src/lib/cli/inplace/index.ts
+++ b/src/lib/cli/inplace/index.ts
@@ -46,6 +46,7 @@ export default defineYargsModule(
             isValidUsage: undefined,
             subprojectPath: "/",
             isIgnoredFile: args.ignoredFileRe ? new RegExp(args.ignoredFileRe) : undefined,
+            domReferenceFactories: undefined,
         };
 
         const config = resolveStatsConfig(unresolvedConfig);

--- a/src/lib/cli/resolveStatsConfig.ts
+++ b/src/lib/cli/resolveStatsConfig.ts
@@ -44,7 +44,16 @@ const hasTsconfigPath = hasProp(tsconfigPathKey);
 const jsconfigPathKey: StringKeys<StatsConfig> = "jsconfigPath";
 const hasJsconfigPath = hasProp(jsconfigPathKey);
 
-const isMultiTargetModuleOrPathDefinition = isObjectOf(isString, isRegexp);
+const domReferenceFactoriesKey: StringKeys<StatsConfig> = "domReferenceFactories";
+const hasDomReferenceFactories = hasProp(domReferenceFactoriesKey);
+
+const isStringRegexRecord = isObjectOf(isString, isRegexp);
+
+export const defaultDomReferenceFactories = {
+    "styled-components": /styled-components/,
+    "stitches": /^@stitches/,
+    "emotion": /^@emotion\/styled/,
+};
 
 export const defaultIgnoreFileRe = /((\.(tests?|specs?|stories|story)\.)|(\/(tests?|specs?|stories|story)\/)|(\/node_modules\/)|(\/__mocks__\/)|(\.d\.ts$))/;
 export const resolveStatsConfig = (config: StatsConfig | unknown): ResolvedStatsConfig => {
@@ -62,7 +71,7 @@ export const resolveStatsConfig = (config: StatsConfig | unknown): ResolvedStats
 
     if (!hasIsTargetModuleOrPath(config)) { throw new Error("Expected the config to specify isTargetModuleOrPath regexp or set"); }
     const isTargetModuleOrPath = config.isTargetModuleOrPath;
-    if (!isRegexp(isTargetModuleOrPath) && !isMultiTargetModuleOrPathDefinition(isTargetModuleOrPath)) {
+    if (!isRegexp(isTargetModuleOrPath) && !isStringRegexRecord(isTargetModuleOrPath)) {
         throw new Error(`Expected a regexp or a set of regexp isTargetModuleOrPath, got: ${ isTargetModuleOrPath }`);
     }
     if (!isRegexp(isTargetModuleOrPath)) {
@@ -80,6 +89,11 @@ export const resolveStatsConfig = (config: StatsConfig | unknown): ResolvedStats
     const isValidUsage = hasIsValidUsage(config) && config.isValidUsage ? config.isValidUsage : () => true;
     if (!isFunction(isValidUsage)) { throw new Error(`Expected isTargetImport to be a filter function if given, got: ${ isTargetImport }`); }
 
+    const domReferenceFactories = hasDomReferenceFactories(config) ? config.domReferenceFactories : defaultDomReferenceFactories;
+    if (!isStringRegexRecord(domReferenceFactories)) {
+        throw new Error(`Expected a set of regexps in domReferenceFactories, got: ${ domReferenceFactories }`);
+    }
+
     return {
         subprojectPath,
         tsconfigPath,
@@ -88,5 +102,6 @@ export const resolveStatsConfig = (config: StatsConfig | unknown): ResolvedStats
         isTargetModuleOrPath,
         isTargetImport: isTargetImport as ResolvedStatsConfig["isTargetImport"],
         isValidUsage: isValidUsage as ResolvedStatsConfig["isValidUsage"],
+        domReferenceFactories,
     };
 };

--- a/src/lib/cli/sharedTypes.ts
+++ b/src/lib/cli/sharedTypes.ts
@@ -11,6 +11,7 @@ type StatsConfigBase = {
     isTargetImport?: (imp: Import) => boolean,
     isValidUsage?: (use: Usage & { source: "homebrew" | Target }) => boolean,
     subprojectPath?: string,
+    domReferenceFactories?: Record<string, RegExp>,
 };
 
 type ExclusiveConfigPaths = { tsconfigPath?: null, jsconfigPath?: null }

--- a/src/lib/cli/util/cache.ts
+++ b/src/lib/cli/util/cache.ts
@@ -20,6 +20,7 @@ const cacheConfigKeys: { [P in StringKeys<CacheConfig>]-?: null } = {
     subprojectPath: null,
     tsconfigPath: null,
     jsconfigPath: null,
+    domReferenceFactories: null,
 };
 
 export const cacheFileName = (config: CacheConfig) => {


### PR DESCRIPTION
This allows specifying regexes matching libs that wrap DOM components in config, e.g. `styled-components` that create raw DOM elements via `styled.div`